### PR TITLE
Add 30-day YouTube Shorts topics plan

### DIFF
--- a/topics.csv
+++ b/topics.csv
@@ -1,4 +1,90 @@
-Box vs $80 Cat Bed
-Cat vs The Red Dot
-Vacuum Bossfight — Victory by Socket
-Top 5 budget phones under $300
+2025-09-20 | shorts_cat | Pumpkin spice zoomies at breakfast
+2025-09-20 | shorts_cat | Grandma's knitting rescue by tuxedo cat
+2025-09-20 | shorts_tech | Best $299 foldable-style phone picks
+2025-09-21 | shorts_cat | Sleepy tabby guarding Sunday pancakes
+2025-09-21 | shorts_cat | Kitten photobombs fantasy football draft
+2025-09-21 | shorts_tech | Top $199 earbuds with multi-device pairing
+2025-09-22 | shorts_cat | Office chair coup by calico CEO
+2025-09-22 | shorts_cat | Laundry basket pirate adventure
+2025-09-22 | shorts_tech | Top $129 MagSafe power banks this fall
+2025-09-23 | shorts_cat | Cat DJ mixes lo-fi study beats
+2025-09-23 | shorts_cat | Orange kitty delivers mailroom morale
+2025-09-23 | shorts_tech | Best $349 Androids for college starters
+2025-09-24 | shorts_cat | Sibling cats host pajama runway show
+2025-09-24 | shorts_cat | Rescue cat tutors remote math class
+2025-09-24 | shorts_tech | Quiet $199 ANC earbuds for commuters
+2025-09-25 | shorts_cat | Senior cat leads sunrise stretch club
+2025-09-25 | shorts_cat | Tabby babysits backyard campout
+2025-09-25 | shorts_tech | Smartwatch deals under $250 this week
+2025-09-26 | shorts_cat | Maine coon orders drive-thru puppuccino
+2025-09-26 | shorts_cat | Kittens chase laser halftime show
+2025-09-26 | shorts_tech | Best $399 Chromebooks for streaming
+2025-09-27 | shorts_cat | Cat lifeguard saves spilled lemonade
+2025-09-27 | shorts_cat | Whisker chef perfects mini tacos
+2025-09-27 | shorts_tech | Top $189 smart home hubs for renters
+2025-09-28 | shorts_cat | Tiny hero stops rogue robot vacuum
+2025-09-28 | shorts_cat | Cat coach leads peewee soccer drills
+2025-09-28 | shorts_tech | Affordable $299 action cams for fall trips
+2025-09-29 | shorts_cat | Dapper cat hosts tea party etiquette
+2025-09-29 | shorts_cat | Barn cat wrangles leaf blower chaos
+2025-09-29 | shorts_tech | Best $149 studio mics for creators
+2025-09-30 | shorts_cat | Skateboard cat cruises boardwalk sunsets
+2025-09-30 | shorts_cat | Cat librarian recommends cozy mysteries
+2025-09-30 | shorts_tech | Budget $329 5G phones for travelers
+2025-10-01 | shorts_cat | Curious kitten unboxes mystery snack crate
+2025-10-01 | shorts_cat | Cat meteorologist predicts cuddle storms
+2025-10-01 | shorts_tech | Top $199 rugged tablets for field work
+2025-10-02 | shorts_cat | Cat therapist calms midterm stress
+2025-10-02 | shorts_cat | Jazz trio backed by purring bassist
+2025-10-02 | shorts_tech | Best $139 wireless earbuds for gym
+2025-10-03 | shorts_cat | Pumpkin patch guard cat saves hayride
+2025-10-03 | shorts_cat | Cat director remakes sci-fi trailer
+2025-10-03 | shorts_tech | Top $379 ultrawide monitors for gamers
+2025-10-04 | shorts_cat | Kitten tailors Halloween costumes early
+2025-10-04 | shorts_cat | Cat barista crafts foam heart art
+2025-10-04 | shorts_tech | Best $259 smart rings for wellness
+2025-10-05 | shorts_cat | Whiskers win family board game night
+2025-10-05 | shorts_cat | Cat camp counselor packs mini s'mores
+2025-10-05 | shorts_tech | Budget $189 dash cams with night vision
+2025-10-06 | shorts_cat | Cat tutor helps kids spell October
+2025-10-06 | shorts_cat | Ninja cat steals socks mid livestream
+2025-10-06 | shorts_tech | Top $349 Windows laptops on sale
+2025-10-07 | shorts_cat | Therapy cat greets returning soldiers
+2025-10-07 | shorts_cat | Cat sous-chef plates fall harvest feast
+2025-10-07 | shorts_tech | Best $129 mechanical keyboards
+2025-10-08 | shorts_cat | Calico coach teaches toddler dance
+2025-10-08 | shorts_cat | Cat mail carrier delivers fan art
+2025-10-08 | shorts_tech | Top $299 noise-cancel cans for focus
+2025-10-09 | shorts_cat | Pumpkin spice cat cafe opening day
+2025-10-09 | shorts_cat | Cat gamer speedruns cozy indie
+2025-10-09 | shorts_tech | Best $219 budget projectors for dorms
+2025-10-10 | shorts_cat | Cat DJ spins vintage vinyl brunch
+2025-10-10 | shorts_cat | Kitten lifter spots home workouts
+2025-10-10 | shorts_tech | Top $179 fitness trackers midseason
+2025-10-11 | shorts_cat | Cat art critic reviews kid paintings
+2025-10-11 | shorts_cat | Rescue cat leads fire drill practice
+2025-10-11 | shorts_tech | Best $329 photo-friendly smartphones
+2025-10-12 | shorts_cat | Cat babysitter narrates bedtime tales
+2025-10-12 | shorts_cat | Whisker weatherman chases rainbows
+2025-10-12 | shorts_tech | Top $149 gaming earbuds with mic
+2025-10-13 | shorts_cat | Cat scientist tests gravity on snacks
+2025-10-13 | shorts_cat | Tabby hosts gratitude journaling club
+2025-10-13 | shorts_tech | Best $399 2-in-1 laptops for grads
+2025-10-14 | shorts_cat | Cat costume designer tweaks hero capes
+2025-10-14 | shorts_cat | Sleepy cat guards baby monitor feed
+2025-10-14 | shorts_tech | Top $219 smart speakers with displays
+2025-10-15 | shorts_cat | Cat drone pilot films fall foliage
+2025-10-15 | shorts_cat | Kitten yoga instructor leads stretch
+2025-10-15 | shorts_tech | Best $189 e-ink readers for travel
+2025-10-16 | shorts_cat | Cat baker decorates apple pie bites
+2025-10-16 | shorts_cat | Tuxedo cat moderates family debate
+2025-10-16 | shorts_tech | Top $349 gaming handhelds October
+2025-10-17 | shorts_cat | Cat mechanic fixes remote control car
+2025-10-17 | shorts_cat | Whisker news anchor breaks feel-good
+2025-10-17 | shorts_tech | Best $299 tablets for note-taking
+2025-10-18 | shorts_cat | Cat lifter rescues stuck closet door
+2025-10-18 | shorts_cat | Kitten hosts kindness postcard swap
+2025-10-18 | shorts_tech | Top $159 Bluetooth speakers patio
+2025-10-19 | shorts_cat | Cat pilot guides paper airplane derby
+2025-10-19 | shorts_cat | Calico hero finds missing homework
+2025-10-19 | shorts_tech | Best $249 budget drones with 4K


### PR DESCRIPTION
## Summary
- add a refreshed `topics.csv` covering a 30-day schedule for US viewers
- ensure each day includes two meme-cat shorts and one tech pick within $100-$400

## Testing
- not run (content-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ce947e7200832f84362961d35bbf3e