### PR TITLE
chore: add keepalive workflow

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,31 @@
+name: keepalive-and-daily-run
+
+on:
+  schedule:
+    # каждые 10 минут — будим Render (время UTC)
+    - cron: "*/10 * * * *"
+    # ежедневные запуски пайплайна: 09:00 и 21:00 по Алматы (UTC+6) => 03:00 и 15:00 UTC
+    - cron: "0 3,15 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: youtube-keepalive
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wake up Render (health)
+        run: curl -fsS https://youtube-zkp6.onrender.com/health || true
+
+  daily:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trends refresh (ignore errors if endpoint missing)
+        run: curl -fsS -X POST https://youtube-zkp6.onrender.com/trends/refresh || true
+      - name: Generate queue
+        run: curl -fsS -X POST https://youtube-zkp6.onrender.com/trends/generate || true
+      - name: Run queue (upload)
+        run: curl -fsS -X POST https://youtube-zkp6.onrender.com/run/queue || true


### PR DESCRIPTION
## Motivation
- Ensure Render-hosted services stay warm and automate daily pipeline triggers.

## Changes
- Add keepalive GitHub Actions workflow that pings health endpoint every 10 minutes.
- Add scheduled daily pipeline triggers for refresh, queue generation, and upload endpoints with workflow dispatch support.

## Migrations
- None.

## Deployment Instructions
- No additional steps required beyond merging; workflow will activate automatically.

## Checklist
- [x] Code builds locally (N/A — workflow only)
- [x] Tests pass locally (N/A — workflow only)
- [x] Relevant documentation updated (N/A)


------
https://chatgpt.com/codex/tasks/task_e_68cee0813fcc832fb56aa15001099f5f