### PR TITLE
chore: add keepalive workflow

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,31 +1,34 @@
-name: keepalive-and-daily-run
+name: keepalive-and-3x-daily
 
 on:
   schedule:
-    # каждые 10 минут — будим Render (время UTC)
+    # keepalive каждые 10 минут (UTC)
     - cron: "*/10 * * * *"
-    # ежедневные запуски пайплайна: 09:00 и 21:00 по Алматы (UTC+6) => 03:00 и 15:00 UTC
-    - cron: "0 3,15 * * *"
+    # три запуска в день: 08:30, 14:30, 20:30 по Asia/Almaty (UTC+6) => 02:30, 08:30, 14:30 UTC
+    - cron: "30 2,8,14 * * *"
   workflow_dispatch:
 
-concurrency:
-  group: youtube-keepalive
-  cancel-in-progress: true
+env:
+  BASE: https://youtube-zkp6.onrender.com
+  BATCH: "1"  # по одному шорту за запуск → 3/день
 
 jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Wake up Render (health)
-        run: curl -fsS https://youtube-zkp6.onrender.com/health || true
+      - name: Wake up Render
+        run: curl -fsS "$BASE/health" || true
 
   daily:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - name: Trends refresh (ignore errors if endpoint missing)
-        run: curl -fsS -X POST https://youtube-zkp6.onrender.com/trends/refresh || true
-      - name: Generate queue
-        run: curl -fsS -X POST https://youtube-zkp6.onrender.com/trends/generate || true
-      - name: Run queue (upload)
-        run: curl -fsS -X POST https://youtube-zkp6.onrender.com/run/queue || true
+      - name: Refresh ideas
+        run: curl -fsS -X POST "$BASE/ideas/refresh" || true
+      - name: Generate N ideas into queue (no-op if generator expects separate step)
+        run: |
+          for i in $(seq 1 $BATCH); do
+            curl -fsS -X POST "$BASE/trends/generate" || true
+          done
+      - name: Upload queue
+        run: curl -fsS -X POST "$BASE/run/queue" || true


### PR DESCRIPTION
## Summary
- add keepalive workflow to ping Render health endpoint and run daily generation tasks

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cefd28073c832fa5e55974c2499b07