### PR TITLE
chore: remove unused pytrends dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,4 @@ google-auth-oauthlib==1.2.1
 fastapi==0.112.2
 uvicorn==0.30.6
 imageio-ffmpeg==0.5.1
-
-pytrends==0.12.0
 httpx==0.27.2


### PR DESCRIPTION
## Motivation
- `pytrends` is no longer referenced anywhere in the codebase, so keeping it in the dependency list adds unnecessary install surface.

## Changes
- Removed the unused `pytrends` entry from `requirements.txt`.

## Migration
- No database or runtime migrations required.

## Deployment
- Rebuild environment layers to pick up the slimmer dependency set.

## Checklist
- [x] `pip install -r requirements.txt` *(fails to reach PyPI for `httpx` because of proxy restrictions in the current environment; all other packages already satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68cf001d04d0832f9816a057b9039a0b