### PR TITLE
fix: harden queue rendering and uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@
 
 Базовый health-check: `GET /health`. Документация: `GET /docs`.
 
+### Быстрый старт через Swagger UI
+
+1. Перейдите на `/docs`, нажмите **Authorize** и вставьте `ADMIN_TOKEN`, если он задан.
+2. В секции **/trends/generate** нажмите **Try it out** и вставьте пример:
+   ```json
+   {
+     "topics": [
+       {
+         "title": "Test topic",
+         "lines": ["Hook", "Twist"],
+         "tags": ["shorts", "demo"]
+       }
+     ]
+   }
+   ```
+   После **Execute** должно вернуться `{ "count": 1 }`.
+3. В секции **/run/queue** вызовите эндпоинт с телом `{"topics": "all", "upload": true, "dry_run": true}` — сервис выполнит сборку, но пропустит фактическую загрузку. Ответ содержит `status: "ok"` и `produced` ≥ 1.
+4. Для реального аплоада снимите `dry_run` и повторите вызов; при успешном аплоаде в логах появится `videoId`, а в ответе — статус `uploaded`.
+
 ## Ротация расписания
 
 - `tasks/seed_month.py` генерирует 30 слотов (по умолчанию 09:00 ET) и отправляет их в очередь. Можно вызвать `python -m tasks.seed_month --start 2025-01-01 --days 30 --slot "09:00 ET" --dry-run`.

--- a/build_short.py
+++ b/build_short.py
@@ -1,9 +1,11 @@
 # ruff: noqa
 
-from moviepy.editor import *
-from PIL import Image, ImageDraw, ImageFont
-from pathlib import Path
 import textwrap
+
+from moviepy.editor import AudioFileClip, ImageClip, concatenate_videoclips
+from PIL import Image, ImageDraw, ImageFont
+
+from utils.video_io import as_np_frame
 
 FONT = None
 
@@ -35,7 +37,7 @@ def caption_frame(text: str, size=(1080,1920), bg=(20,20,25), fg=(255,255,255), 
         draw.rectangle((x-14, y-10, x+tw+14, y+th+10), fill=(0,0,0,140))
         draw.text((x, y), ln, font=FONT, fill=fg)
         y += th + 28
-    return ImageClip(img).set_duration(2.0)
+    return ImageClip(as_np_frame(img)).set_duration(2.0)
 
 def assemble_short(lines: list[str], audio_path: str, title: str, out_path: str, fps=30, resolution=(1080,1920)):
     aclip = AudioFileClip(audio_path)

--- a/core/upload.py
+++ b/core/upload.py
@@ -140,6 +140,13 @@ def upload_manifest(manifest_path: str, settings_path: str) -> list[dict[str, st
             validate_video(video_info)
             schedule_utc = _parse_schedule(entry.get("schedule"), settings)
             publish_at = _ensure_future_publish_at(schedule_utc)
+            logger.info(
+                "Prepared upload entry",
+                extra={
+                    "title": metadata.title,
+                    "publishAt": publish_at.isoformat() if publish_at else None,
+                },
+            )
             privacy_status = privacy_status_default
             if publish_at is not None:
                 privacy_status = "private"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
 fastapi
 uvicorn[standard]
-moviepy==1.0.3
+moviepy>=1.0.3
+numpy>=1.24
+Pillow>=10
+imageio>=2.34
+imageio-ffmpeg>=0.4.9
 gTTS==2.5.1
 google-api-python-client
 google-auth
 google-auth-oauthlib
 PyYAML
 python-dotenv
-Pillow
 requests
 pytest

--- a/tests/test_run_queue.py
+++ b/tests/test_run_queue.py
@@ -28,11 +28,12 @@ def _setup_oauth(monkeypatch):
     monkeypatch.setenv("YOUTUBE_CLIENT_SECRET_JSON", json.dumps(client_payload))
     monkeypatch.setenv("YOUTUBE_TOKEN_JSON", json.dumps(token_payload))
     monkeypatch.setenv("CHANNEL_DEFAULT_TAGS", "shorts,test")
+    monkeypatch.setenv("YOUTUBE_SCOPES", "https://www.googleapis.com/auth/youtube.upload")
     monkeypatch.delenv("ADMIN_TOKEN", raising=False)
     yield
 
 
-def test_run_queue_dry_run(monkeypatch, tmp_path):
+def test_run_queue_dry_run_ok(monkeypatch, tmp_path):
     import server
     from core import generate
 
@@ -54,7 +55,7 @@ def test_run_queue_dry_run(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "build_all", fake_build_all)
 
-    request = server.RunQueueRequest(topics="all", upload=False)
+    request = server.RunQueueRequest(topics="all", upload=True, dry_run=True)
     response = server.run_queue(request)
 
     assert response.status == "ok"

--- a/tests/test_video_io.py
+++ b/tests/test_video_io.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+from moviepy.editor import ImageSequenceClip
+from PIL import Image
+
+from utils.video_io import as_np_frame, as_np_frames
+
+
+def test_as_np_frame_pil_to_np() -> None:
+    img = Image.new("RGB", (4, 2), color=(10, 20, 30))
+    frame = as_np_frame(img)
+
+    assert isinstance(frame, np.ndarray)
+    assert frame.shape == (2, 4, 3)
+    assert frame.dtype == np.uint8
+    assert frame[0, 0, 0] == 10
+
+
+def test_image_sequence_clip_accepts_pil_list() -> None:
+    frames = [Image.new("RGB", (4, 4), color=(index, index, index)) for index in range(3)]
+    clip = ImageSequenceClip(as_np_frames(frames), fps=2)
+
+    # Ensure clip can render a few frames without invoking ffmpeg writes
+    snapshot = clip.get_frame(0)
+    assert snapshot.shape == (4, 4, 3)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for media processing and other shared routines."""
+
+from .video_io import as_np_frame, as_np_frames
+
+__all__ = ["as_np_frame", "as_np_frames"]

--- a/utils/video_io.py
+++ b/utils/video_io.py
@@ -1,0 +1,42 @@
+"""Adapters for coercing arbitrary image/frame objects into numpy arrays."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+def as_np_frame(source: object) -> np.ndarray:
+    """Return an RGB numpy frame for MoviePy from multiple input types."""
+
+    if isinstance(source, np.ndarray):
+        return source
+    if isinstance(source, Image.Image):
+        return np.array(source.convert("RGB"))
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        try:
+            pil_image = Image.open(path)
+        except Exception as exc:  # pragma: no cover - delegated to PIL
+            logger.error("Failed to open image", extra={"path": path.as_posix(), "error": str(exc)})
+            raise
+        try:
+            return np.array(pil_image.convert("RGB"))
+        finally:
+            pil_image.close()
+    raise TypeError(f"Unsupported frame type: {type(source)!r}")
+
+
+def as_np_frames(frames: Iterable[object]) -> list[np.ndarray]:
+    """Convert an iterable of frame-like objects into numpy arrays."""
+
+    return [as_np_frame(frame) for frame in frames]
+
+
+__all__: Sequence[str] = ["as_np_frame", "as_np_frames"]


### PR DESCRIPTION
## Summary
- add shared video frame adapter to normalise PIL images before MoviePy
- harden /run/queue with structured logging, dry-run handling and upload env validation
- log publishAt when scheduling uploads and refresh documentation for Swagger usage
- bump media dependencies and extend pytest coverage for video adapters and run queue dry-run

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0312229a4832f848f83807f013b94