### PR TITLE
Fix MoviePy import compatibility for v2

### DIFF
--- a/build_short.py
+++ b/build_short.py
@@ -2,7 +2,10 @@
 
 import textwrap
 
-from moviepy.editor import AudioFileClip, ImageClip, concatenate_videoclips
+try:
+    from moviepy import AudioFileClip, ImageClip, concatenate_videoclips
+except ImportError:  # pragma: no cover - fallback for MoviePy<2.0
+    from moviepy.editor import AudioFileClip, ImageClip, concatenate_videoclips
 from PIL import Image, ImageDraw, ImageFont
 
 from utils.video_io import as_np_frame

--- a/core/metadata.py
+++ b/core/metadata.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from moviepy.editor import VideoFileClip
+try:
+    from moviepy import VideoFileClip
+except ImportError:  # pragma: no cover - fallback for MoviePy<2.0
+    from moviepy.editor import VideoFileClip
 
 TITLE_LIMIT = 100
 DESCRIPTION_LIMIT = 4900

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn[standard]
-moviepy>=1.0.3
+moviepy>=2.2
 numpy>=1.24
 Pillow>=10
 imageio>=2.34

--- a/tests/test_video_io.py
+++ b/tests/test_video_io.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import numpy as np
-from moviepy.editor import ImageSequenceClip
+
+try:
+    from moviepy import ImageSequenceClip
+except ImportError:  # pragma: no cover - fallback for MoviePy<2.0
+    from moviepy.editor import ImageSequenceClip
 from PIL import Image
 
 from utils.video_io import as_np_frame, as_np_frames


### PR DESCRIPTION
## Summary
- switch all moviepy.editor imports to the MoviePy v2 style with a fallback for v1.x
- bump the moviepy requirement to v2.2 while keeping imageio-ffmpeg at the expected floor

## Testing
- PYTHONPATH="/tmp/stubs:$PYTHONPATH" uvicorn server:app (startup only)
- curl -s -o /tmp/run_queue_response.json -w "%{http_code}" -X POST http://127.0.0.1:8000/run/queue -H "Content-Type: application/json" -d '{"topics":"all","upload":true,"dry_run":true}'

------
https://chatgpt.com/codex/tasks/task_e_68d033f51100832fafdbbf719adf347b