### PR TITLE
fix: adapt MoviePy usage to v2 API

### DIFF
--- a/build_short.py
+++ b/build_short.py
@@ -3,9 +3,9 @@
 import textwrap
 
 try:
-    from moviepy import AudioFileClip, ImageClip, concatenate_videoclips
+    from moviepy import AudioFileClip, ImageClip, CompositeVideoClip, TextClip, concatenate_videoclips, vfx
 except ImportError:  # pragma: no cover - fallback for MoviePy<2.0
-    from moviepy.editor import AudioFileClip, ImageClip, concatenate_videoclips
+    from moviepy.editor import AudioFileClip, ImageClip, CompositeVideoClip, TextClip, concatenate_videoclips, vfx
 from PIL import Image, ImageDraw, ImageFont
 
 from utils.video_io import as_np_frame
@@ -40,13 +40,13 @@ def caption_frame(text: str, size=(1080,1920), bg=(20,20,25), fg=(255,255,255), 
         draw.rectangle((x-14, y-10, x+tw+14, y+th+10), fill=(0,0,0,140))
         draw.text((x, y), ln, font=FONT, fill=fg)
         y += th + 28
-    return ImageClip(as_np_frame(img)).set_duration(2.0)
+    return ImageClip(as_np_frame(img), duration=2.0)
 
 def assemble_short(lines: list[str], audio_path: str, title: str, out_path: str, fps=30, resolution=(1080,1920)):
     aclip = AudioFileClip(audio_path)
     seg = max(1.8, aclip.duration / max(1, len(lines)))
-    clips = [caption_frame(ln, size=resolution).set_duration(seg) for ln in lines]
-    v = concatenate_videoclips(clips, method="compose").set_audio(aclip)
+    clips = [caption_frame(ln, size=resolution).with_duration(seg) for ln in lines]
+    v = concatenate_videoclips(clips, method="compose").with_audio(aclip)
     v.write_videofile(out_path, fps=fps, codec="libx264", audio_codec="aac")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation
- MoviePy v2 removes legacy `set_*` mutators, breaking `/run/queue` when rendering Shorts with still frames.

## Changes
- Switched MoviePy imports to the v2-compatible module path fallback.
- Replaced deprecated `set_*` chaining with the new `with_*`/constructor parameters for clip duration and audio.

## Migrations
- None.

## Deployment
- Backend: `export PYTHONPATH="$(pwd)" && alembic -c alembic.ini upgrade head && uvicorn app.main:app --host 0.0.0.0 --port $PORT`
- Frontend: `cd frontend && npm i && npm run build`

## Checklist
- [x] Tests passing (`pytest`)
- [x] /health reachable
- [x] Admin login works
- [x] CORS configured
- [x] Frontend uses `VITE_API_URL`


------
https://chatgpt.com/codex/tasks/task_e_68d039600b94832fb2f4c53ab37988cb