### PR TITLE
Fix MoviePy v2 compatibility

### DIFF
--- a/build_short.py
+++ b/build_short.py
@@ -9,10 +9,15 @@ except ImportError:  # pragma: no cover - fallback for MoviePy<2.0
 from PIL import Image, ImageDraw, ImageFont
 
 from utils.video_io import as_np_frame
+from utils.moviepy_compat import (
+    clip_with_audio,
+    clip_with_duration,
+)
 
 FONT = None
 
-def load_font(path: str, size: int):
+def load_font(path: str, size: int) -> None:
+    """Загрузить пользовательский шрифт для подписей."""
     global FONT
     try:
         FONT = ImageFont.truetype(path, size)
@@ -20,7 +25,14 @@ def load_font(path: str, size: int):
         # Fallback to default PIL font
         FONT = ImageFont.load_default()
 
-def caption_frame(text: str, size=(1080,1920), bg=(20,20,25), fg=(255,255,255), pad=40):
+def caption_frame(
+    text: str,
+    size: tuple[int, int] = (1080, 1920),
+    bg: tuple[int, int, int] = (20, 20, 25),
+    fg: tuple[int, int, int] = (255, 255, 255),
+    pad: int = 40,
+):
+    """Создать кадр ``ImageClip`` с перенесённым текстом."""
     img = Image.new("RGB", size, bg)
     draw = ImageDraw.Draw(img)
     w, h = size
@@ -42,11 +54,19 @@ def caption_frame(text: str, size=(1080,1920), bg=(20,20,25), fg=(255,255,255), 
         y += th + 28
     return ImageClip(as_np_frame(img), duration=2.0)
 
-def assemble_short(lines: list[str], audio_path: str, title: str, out_path: str, fps=30, resolution=(1080,1920)):
+def assemble_short(
+    lines: list[str],
+    audio_path: str,
+    title: str,
+    out_path: str,
+    fps: int = 30,
+    resolution: tuple[int, int] = (1080, 1920),
+):
+    """Собрать короткое видео из слайдов и озвучки."""
     aclip = AudioFileClip(audio_path)
     seg = max(1.8, aclip.duration / max(1, len(lines)))
-    clips = [caption_frame(ln, size=resolution).with_duration(seg) for ln in lines]
-    v = concatenate_videoclips(clips, method="compose").with_audio(aclip)
+    clips = [clip_with_duration(caption_frame(ln, size=resolution), seg) for ln in lines]
+    v = clip_with_audio(concatenate_videoclips(clips, method="compose"), aclip)
     v.write_videofile(out_path, fps=fps, codec="libx264", audio_codec="aac")
 
 if __name__ == "__main__":

--- a/tests/test_moviepy_compat.py
+++ b/tests/test_moviepy_compat.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+
+from utils import moviepy_compat as compat
+
+
+class HybridClip:
+    """Test double exposing both modern and legacy methods."""
+
+    def __init__(self) -> None:
+        self.invocations: list[tuple[str, float]] = []
+
+    def with_duration(self, duration: float) -> "HybridClip":
+        self.invocations.append(("with", duration))
+        return self
+
+    def set_duration(self, duration: float) -> "HybridClip":
+        self.invocations.append(("set", duration))
+        return self
+
+
+class LegacyClip:
+    """Test double that only provides the legacy MoviePy API surface."""
+
+    def __init__(self) -> None:
+        self.called: list[float] = []
+
+    def set_duration(self, duration: float) -> "LegacyClip":
+        self.called.append(duration)
+        return self
+
+    def set_audio(self, audio: object) -> "LegacyClip":
+        self.called.append(-1.0)
+        return self
+
+
+def test_clip_with_duration_prefers_modern_method() -> None:
+    clip = HybridClip()
+
+    result = compat.clip_with_duration(clip, 2.5)
+
+    assert result is clip
+    assert clip.invocations == [("with", 2.5)]
+
+
+def test_clip_with_duration_falls_back_to_legacy() -> None:
+    clip = LegacyClip()
+
+    result = compat.clip_with_duration(clip, 1.0)
+
+    assert result is clip
+    assert clip.called == [1.0]
+
+
+def test_clip_with_audio_falls_back_to_legacy() -> None:
+    clip = LegacyClip()
+
+    result = compat.clip_with_audio(clip, object())
+
+    assert result is clip
+    assert clip.called[-1] == -1.0
+
+
+def test_clip_with_audio_fadein_uses_fx(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FxClip:
+        def __init__(self) -> None:
+            self.args: tuple[object, float] | None = None
+
+        def fx(self, func: object, duration: float) -> "FxClip":
+            self.args = (func, duration)
+            return self
+
+    clip = FxClip()
+
+    result = compat.clip_with_audio_fadein(clip, 0.75)
+
+    assert result is clip
+    assert clip.args is not None
+    assert clip.args[1] == 0.75
+
+
+def test_clip_with_audio_fadein_legacy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    class LegacyFadeClip:
+        def __init__(self) -> None:
+            self.called: list[float] = []
+
+        def audio_fadein(self, duration: float) -> "LegacyFadeClip":
+            self.called.append(duration)
+            return self
+
+    clip = LegacyFadeClip()
+    monkeypatch.setattr(compat, "audio_fx", None)
+
+    result = compat.clip_with_audio_fadein(clip, 1.5)
+
+    assert result is clip
+    assert clip.called == [1.5]
+
+
+def test_clip_with_audio_fadeout_legacy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    class LegacyFadeClip:
+        def __init__(self) -> None:
+            self.called: list[float] = []
+
+        def audio_fadeout(self, duration: float) -> "LegacyFadeClip":
+            self.called.append(duration)
+            return self
+
+    clip = LegacyFadeClip()
+    monkeypatch.setattr(compat, "audio_fx", None)
+
+    result = compat.clip_with_audio_fadeout(clip, 2.0)
+
+    assert result is clip
+    assert clip.called == [2.0]

--- a/utils/moviepy_compat.py
+++ b/utils/moviepy_compat.py
@@ -1,0 +1,131 @@
+"""Совместимость между API MoviePy 1.x и 2.x.
+
+Функции ниже сначала пытаются использовать современный интерфейс ``with_*`` из
+MoviePy 2.x, а при его отсутствии откатываются к легаси-методам ``set_*`` из
+MoviePy 1.x. Это позволяет писать код под новую версию и при этом не ломать
+локальные окружения, где ещё не произошёл апгрейд.
+
+Каждый хелпер повторяет сигнатуру соответствующего метода ``with_*`` и
+возвращает исходный клип после применения преобразования.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+try:  # pragma: no cover - optional for MoviePy<2.0
+    from moviepy import vfx
+except ImportError:  # pragma: no cover - fallback for MoviePy 1.x
+    from moviepy.video.fx import all as vfx  # type: ignore
+
+try:  # pragma: no cover - available on both branches, but defensive
+    from moviepy.audio.fx import all as audio_fx
+except ImportError:  # pragma: no cover - very old MoviePy versions
+    audio_fx = None  # type: ignore[assignment]
+
+
+ClipT = TypeVar("ClipT")
+
+
+def _call_preferred(
+    clip: ClipT,
+    modern: str,
+    legacy: str,
+    *args: Any,
+    **kwargs: Any,
+) -> ClipT:
+    """Вызвать метод ``modern`` или откатиться к ``legacy``."""
+
+    preferred = getattr(clip, modern, None)
+    if callable(preferred):
+        return preferred(*args, **kwargs)
+
+    fallback = getattr(clip, legacy, None)
+    if callable(fallback):
+        return fallback(*args, **kwargs)
+
+    raise AttributeError(
+        f"{clip!r} does not implement '{modern}' or '{legacy}' methods",
+    )
+
+
+def clip_with_duration(clip: ClipT, duration: float) -> ClipT:
+    """Выставить длительность клипа с учётом версии MoviePy."""
+
+    return _call_preferred(clip, "with_duration", "set_duration", duration)
+
+
+def clip_with_position(clip: ClipT, position: Any) -> ClipT:
+    """Разместить клип на заданной позиции композиции."""
+
+    return _call_preferred(clip, "with_position", "set_position", position)
+
+
+def clip_with_fps(clip: ClipT, fps: float) -> ClipT:
+    """Изменить FPS клипа вне зависимости от API."""
+
+    return _call_preferred(clip, "with_fps", "set_fps", fps)
+
+
+def clip_with_start(clip: ClipT, start: float) -> ClipT:
+    """Сдвинуть старт клипа на ``start`` секунд."""
+
+    return _call_preferred(clip, "with_start", "set_start", start)
+
+
+def clip_with_end(clip: ClipT, end: float) -> ClipT:
+    """Ограничить завершение клипа абсолютной отметкой."""
+
+    return _call_preferred(clip, "with_end", "set_end", end)
+
+
+def clip_with_opacity(clip: ClipT, opacity: float) -> ClipT:
+    """Применить прозрачность к клипу независимо от версии."""
+
+    return _call_preferred(clip, "with_opacity", "set_opacity", opacity)
+
+
+def clip_with_audio(clip: ClipT, audio_clip: Any) -> ClipT:
+    """Прикрепить аудиодорожку, не завися от версии MoviePy."""
+
+    return _call_preferred(clip, "with_audio", "set_audio", audio_clip)
+
+
+def clip_with_audio_fadein(clip: ClipT, duration: float) -> ClipT:
+    """Применить fade-in к аудио с учётом доступного API."""
+
+    if hasattr(clip, "fx") and audio_fx is not None:
+        return clip.fx(audio_fx.audio_fadein, duration)  # type: ignore[attr-defined]
+
+    legacy = getattr(clip, "audio_fadein", None)
+    if callable(legacy):  # pragma: no cover - MoviePy<2 provides bound method
+        return legacy(duration)
+
+    raise AttributeError("Audio fade-in is not supported by this clip")
+
+
+def clip_with_audio_fadeout(clip: ClipT, duration: float) -> ClipT:
+    """Применить fade-out к аудио независимо от версии MoviePy."""
+
+    if hasattr(clip, "fx") and audio_fx is not None:
+        return clip.fx(audio_fx.audio_fadeout, duration)  # type: ignore[attr-defined]
+
+    legacy = getattr(clip, "audio_fadeout", None)
+    if callable(legacy):  # pragma: no cover - MoviePy<2 provides bound method
+        return legacy(duration)
+
+    raise AttributeError("Audio fade-out is not supported by this clip")
+
+
+__all__ = [
+    "clip_with_duration",
+    "clip_with_position",
+    "clip_with_fps",
+    "clip_with_start",
+    "clip_with_end",
+    "clip_with_opacity",
+    "clip_with_audio",
+    "clip_with_audio_fadein",
+    "clip_with_audio_fadeout",
+]
+


### PR DESCRIPTION
## Motivation
- Prevent `/run/queue` failures on MoviePy v2 where legacy `set_*` APIs are removed.
- Keep backwards compatibility for local environments still pinned to MoviePy 1.x.

## Summary
- Add a compatibility layer that prefers MoviePy 2.x `with_*` methods while gracefully falling back to legacy `set_*` calls.
- Update the Shorts assembly pipeline to route duration and audio mutations through the compatibility helpers.
- Cover the new helpers with unit tests to guarantee both modern and legacy code paths behave identically.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d04437ba8c832f8673ec21d097dc21